### PR TITLE
chore: add CHANGELOG.md and .gitmessage

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,38 @@
+#<--- 72 characters --------------------------------------------------->
+#
+# Conventional Commits, semantic commit messages for humans and machines
+# https://www.conventionalcommits.org/en/v1.0.0/
+# Lint your conventional commits
+# https://github.com/conventional-changelog/commitlint/tree/master/%40 \
+#	commitlint/config-conventional
+# Common types can be (based on Angular convention)
+# build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+# https://github.com/conventional-changelog/commitlint/tree/master/%40
+# Footer
+# https://git-scm.com/docs/git-interpret-trailers
+#
+#<--- pattern --------------------------------------------------------->
+#
+# <feat|fix|build|chore|ci|docs|style|refactor|perf|test>[(Scope)][!]: \
+#	<description>
+# short description: <type>[(<scope>)]: <subject>
+#
+# ! after scope in header indicates breaking change
+#
+# [optional body]
+#
+# - with bullets points
+#
+# [optional footer(s)]
+#
+# [BREAKING CHANGE:, Refs:, Resolves:, Addresses:, Reviewed by:]
+#
+#<--- usage ----------------------------------------------------------->
+#
+# Set locally (in the repository)
+# `git config commit.template .gitmessage`
+#
+# Set globally
+# `git config --global commit.template .gitmessage`
+#
+#<--- 72 characters --------------------------------------------------->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+<!-- markdownlint-disable MD024 no-duplicate-heading -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+**Types of changes**: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
+
+## [Unreleased]
+
+### Added
+
+- Idle discovery mechanism: heartbeat generates goals when queue is empty
+- Goal type taxonomy (6 types) with cost gates in PRD Phase 1
+- Seed goal ("Generate README from repo contents") at Phase 0/1 boundary
+- PR template with conventional commits, self-review, security checklist
+- Issue templates: bug report (GHA/agent context), question (links to docs)
+- `.gitmessage` conventional commits template
+- `CHANGELOG.md`
+
+### Changed
+
+- Phase 7 rewritten: removed `system-strategic-planner.md`, discovery scales via heartbeat
+- Heartbeat role updated to include idle observation and goal generation
+- `README.md`: added Lim Sid nickname
+
+## [0.1.0] - 2026-03-18
+
+### Added
+
+- Architecture doc: two-account model, agent roles, communication, self-reflection, self-supervision, self-evolution, security, tracing
+- PRD: 8-phase roadmap from seed to full autonomy (Phase 0-7)
+- `README.md` with project overview and doc links
+- MIT license, `.gitignore`


### PR DESCRIPTION
## Summary

- `CHANGELOG.md` with Keep a Changelog format matching Agents-eval conventions
- `.gitmessage` conventional commits template

## Test plan

- [ ] CHANGELOG format matches Agents-eval (markdownlint disable, semver, change types header)
- [ ] `.gitmessage` contains conventional commits pattern reference

Generated with Claude <noreply@anthropic.com>