### PR TITLE
chore: rename plugin references to claude-code-plugins

### DIFF
--- a/docs/living-github-account.md
+++ b/docs/living-github-account.md
@@ -219,7 +219,7 @@ Each asset has one integration point. No asset serves two purposes.
 |-------|------|------|
 | **ralph-loop template** | Structural reference for `living-core` | Phase 0: empty repo; cherry-pick patterns as needed |
 | **ralph-loop scripts** | Dev loop engine for workers | Phase 2: git submodule at `ralph/` |
-| **claude-code-utils-plugin** | Skill registry for all agents | Phase 2: `extraKnownMarketplaces` in settings |
+| **claude-code-plugins** | Skill registry for all agents | Phase 2: `extraKnownMarketplaces` in settings |
 | **polyforge** | Multi-repo orchestration from qte77 | Phase 6: qte77 runs `cc-parallel.sh` externally |
 | **coding-agents-research** | Platform intel feed | Phase 4+: posts `repository_dispatch` to living-core |
 | **gha-ai-changelog** | Automated CHANGELOG | Phase 2+: reusable workflow post-merge |

--- a/docs/sprints/sprint1.md
+++ b/docs/sprints/sprint1.md
@@ -108,7 +108,7 @@ The first human-injected goal that proves the loop: **"Generate and maintain you
 | `prompts/system-coder.md` | Worker prompt for implementation |
 | `prompts/system-reviewer.md` | Reviewer prompt for quality scoring |
 | `ralph/` | Git submodule — ralph-loop dev engine |
-| `.claude/settings.json` | `extraKnownMarketplaces: ["qte77/claude-code-utils-plugin"]` |
+| `.claude/settings.json` | `extraKnownMarketplaces: ["qte77/claude-code-plugins"]` |
 
 **AC**:
 - [ ] Code goal -> orchestrator creates stories -> worker runs `make ralph ITERATIONS=5` -> PR


### PR DESCRIPTION
## Summary
- Rename `claude-code-utils-plugin` → `claude-code-plugins` and `qte77-claude-code-utils` → `qte77-claude-code-plugins`

Follows GitHub repo rename qte77/claude-code-utils-plugin → qte77/claude-code-plugins.

🤖 Generated with Claude <noreply@anthropic.com>