### PR TITLE
chore(lint): bump SHA pin and apply inference fixes

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   lint:
-    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@55ea1a9910b7dfe02853437345fd76c009cb858f  # 2026-04-27
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+# Changelog
+
 <!-- markdownlint-disable MD024 no-duplicate-heading -->
 
-# Changelog
+## Changelog
 
 All notable changes to this project will be documented in this file.
 

--- a/docs/UserStory.md
+++ b/docs/UserStory.md
@@ -48,7 +48,7 @@ The collection of workflow-based agents that autonomously plan, execute, review,
 
 ## Workflow Summary
 
-```
+```text
 Operator sets goal ──> repository_dispatch ──> goal-intake workflow
                                                      │
 Heartbeat (idle) ──> discovers goal ─────────────────┘

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,7 +18,7 @@ After this, agents take over.
 ```bash
 gh repo create living-core --public --clone
 cd living-core
-```
+```bash
 
 ### 2. Set secrets
 
@@ -46,7 +46,7 @@ cp /path/to/liminal-flux-gh-acc/docs/stubs/system-orchestrator.md prompts/
 
 # Governance
 cp /path/to/liminal-flux-gh-acc/docs/stubs/AGENTS.md .
-```
+```bash
 
 Review and customize each file before committing. The stubs are starting points — adapt the orchestrator prompt and governance rules to your needs.
 
@@ -62,7 +62,7 @@ The heartbeat workflow starts automatically on the next cron tick (within 15 min
 
 ```bash
 gh workflow run heartbeat
-```
+```bash
 
 ### 5. Verify
 
@@ -98,7 +98,7 @@ EOF
 git add state/goals.json
 git commit -m "feat: inject seed goal"
 git push
-```
+```bash
 
 The next heartbeat picks up the goal, creates a task Issue, and the loop begins.
 

--- a/docs/living-github-account.md
+++ b/docs/living-github-account.md
@@ -11,7 +11,7 @@ GitHub Actions is the agent runtime. The repo is the agent's memory. Issues are 
 
 ## Two-Account Model
 
-```
+```yaml
 qte77 (Command Center)                    liminal-flux (Agent-Operated)
 ─────────────────────────                  ─────────────────────────────
 Sets high-level goals             ──>      living-core/ (brain + state)
@@ -39,7 +39,7 @@ living-account-dashboard/: reports
 
 Only files that exist from Phase 0 are listed as Phase 0. Everything else appears when its phase proves the need.
 
-```
+```bash
 living-core/
   .github/workflows/
     heartbeat.yaml              [Phase 0] Cron */15min — system pulse
@@ -93,7 +93,7 @@ Agents are workflows, not separate services. Each workflow is one agent with one
 
 All inter-agent messages use one format — structured JSON in Issue comments:
 
-````
+````text
 ```agent-message
 {
   "agent": "orchestrator",
@@ -115,7 +115,7 @@ All inter-agent messages use one format — structured JSON in Issue comments:
 
 The reflector is the system's learning loop. It runs daily, not continuously — reflection needs accumulated data to be useful.
 
-```
+```text
 performance-log.jsonl (7 days) ──> Reflector agent ──> Improvement Issues
                                                    ──> agent-memory.md entries
 ```
@@ -140,7 +140,7 @@ performance-log.jsonl (7 days) ──> Reflector agent ──> Improvement Issue
 
 When the goal queue is empty, the heartbeat switches to discovery mode instead of idling. This is one `if/else` in the heartbeat — not a new agent or workflow.
 
-```
+```text
 Heartbeat runs:
   IF goals pending → dispatch them (existing behavior)
   IF no goals pending → run discovery mode:
@@ -254,7 +254,7 @@ permissions:
   issues: write
   pull-requests: write
   actions: read
-```
+```yaml
 
 Never: `admin`, `organization`, `security_events`.
 

--- a/docs/sprints/sprint1.md
+++ b/docs/sprints/sprint1.md
@@ -141,10 +141,10 @@ The first human-injected goal that proves the loop: **"Generate and maintain you
 
 **Feedback loop**:
 
-```
+```text
 Outcomes -> performance-log -> Reflector -> Improvement Issues -> Orchestrator -> Worker -> Better outcomes
                                         -> agent-memory.md -> All agent prompts -> Smarter agents
-```
+```bash
 
 **AC**:
 


### PR DESCRIPTION
## Summary
- Bump `lint-md-links.yml` `uses:` SHA pin to current `qte77/.github` main (2026-04-27, includes #20 schedule-skip-md and #21 cli2 docs)
- Apply markdown inference fixes for canonical lint compliance (where applicable):
  - MD040 (fence language) inferred from block content (bash/python/json/yaml/text)
  - MD041 (first-line H1) inferred from filename
  - MD025 (multiple H1s) demoted to H2
  - MD036 (emphasis-as-heading) converted to H3

Generated with Claude <noreply@anthropic.com>