### PR TITLE
docs: README canon + fix lint/links (remove PRD symlink)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ stubs, and guide -- do not add runtime code.
 
 - docs/living-github-account.md -- system design (components, mechanisms, comms)
 - docs/architecture.md -- architecture decision records
-- docs/PRD.md -- phased roadmap from bootstrap to full autonomy
+- docs/sprints/sprint1.md -- phased roadmap from bootstrap to full autonomy
 - docs/roadmap.md -- vision, phase status, next steps
 - docs/UserStory.md -- personas and workflows
 - docs/deployment.md -- end-to-end bootstrap instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Standardized .claude (AGENTS.md + CLAUDE.md symlink, estate rules, qte77-claude-code-plugins marketplace); README to doc-structure canon; removed the docs/PRD.md symlink and repointed refs to docs/sprints/sprint1.md.
 - Merged `TODO.md` into `roadmap.md` "What's Next" section (DRY)
 - README description rewritten as forward-looking project summary
 - Roadmap Phase 0 status: Design -> Ready to deploy

--- a/README.md
+++ b/README.md
@@ -1,22 +1,37 @@
 # liminal-flux-gh-acc
 
+> Lim Sid - a self-evolving, agent-operated GitHub account
+
 [![License](https://img.shields.io/badge/license-Apache--2.0-58f4c2.svg)](LICENSE)
 ![Version](https://img.shields.io/badge/version-0.2.0-58f4c2.svg)
+[![Lint](https://github.com/qte77/liminal-flux-gh-acc/actions/workflows/lint-md-links.yml/badge.svg)](https://github.com/qte77/liminal-flux-gh-acc/actions/workflows/lint-md-links.yml)
 
-**Lim Sid** — a self-evolving, agent-operated GitHub account. Agents plan, code, review, reflect, supervise, and evolve their own infrastructure. Humans set goals and handle security escalations.
+## What
 
-This repo contains the design docs, seed file templates, and deployment guide for bootstrapping the living account. The system progresses through 8 phases (seed to full autonomy), each proving the previous before adding complexity.
+- Design docs, seed templates, and deployment guide for an agent-operated GitHub account
+- 8-phase progression from seed (Phase 0) to full autonomy
+- Agents plan, code, review, reflect, supervise, and evolve their own infrastructure
+- Humans set goals and handle security escalations
+- Phase 0 ready to deploy; no running infrastructure yet
 
-## Documents
+## How
 
-- [Architecture — System Design](docs/living-github-account.md) — components, mechanisms, communication
-- [Architecture — ADRs](docs/architecture.md) — architecture decision records
-- [PRD](docs/PRD.md) — phased roadmap from bootstrap to full autonomy
-- [Roadmap](docs/roadmap.md) — vision, phase status, and next steps
-- [User Stories](docs/UserStory.md) — personas and workflows
-- [Deployment Guide](docs/deployment.md) — end-to-end bootstrap instructions
-- [Seed File Stubs](docs/stubs/) — templates for living-core bootstrap
+See [docs/deployment.md](docs/deployment.md) for the end-to-end bootstrap.
 
-## Status
+## Why
 
-Phase 0 ready to deploy. Design docs, seed stubs, and deployment guide complete. No running infrastructure yet.
+Incumbent model: human-operated GitHub accounts require continuous human attention to plan, code, review, and maintain infrastructure. This project is a self-evolving, agent-operated account that evolves its own infrastructure — humans set direction, agents do the rest.
+
+## References
+
+- [Architecture: System Design](docs/living-github-account.md)
+- [Architecture: ADRs](docs/architecture.md)
+- [PRD](docs/sprints/sprint1.md)
+- [Roadmap](docs/roadmap.md)
+- [User Stories](docs/UserStory.md)
+- [Deployment Guide](docs/deployment.md)
+- [Seed File Stubs](docs/stubs/)
+
+## License
+
+Apache-2.0 - see [LICENSE](LICENSE).

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,1 +1,0 @@
-sprints/sprint1.md

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,10 +1,10 @@
 # TODO
 
-> Actionable next steps. For acceptance criteria details, see [PRD.md](PRD.md). For big picture, see [roadmap.md](roadmap.md).
+> Actionable next steps. For acceptance criteria details, see [PRD.md](sprints/sprint1.md). For big picture, see [roadmap.md](roadmap.md).
 
 ## Phase 0: Seed
 
-Follow the [Deployment Guide](deployment.md) for step-by-step bootstrap commands. Verify against [PRD Phase 0 AC](PRD.md).
+Follow the [Deployment Guide](deployment.md) for step-by-step bootstrap commands. Verify against [PRD Phase 0 AC](sprints/sprint1.md).
 
 - [ ] Complete deployment guide Phase 0 steps
 - [ ] Inject seed goal per deployment guide Phase 0/1 boundary
@@ -12,7 +12,7 @@ Follow the [Deployment Guide](deployment.md) for step-by-step bootstrap commands
 
 ## Phase 1: Single-Agent Loop
 
-Operational steps. For added/modified files and AC, see [PRD.md](PRD.md) Phase 1.
+Operational steps. For added/modified files and AC, see [PRD.md](sprints/sprint1.md) Phase 1.
 
 - [ ] Add `goal-intake.yaml`, `agent-worker.yaml`, `performance-log.jsonl`
 - [ ] Update heartbeat and orchestrator prompt with goal execution + discovery
@@ -20,7 +20,7 @@ Operational steps. For added/modified files and AC, see [PRD.md](PRD.md) Phase 1
 
 ## Phase 2+
 
-Each phase depends on proving the previous. See [PRD.md](PRD.md) for files, AC, and dependencies.
+Each phase depends on proving the previous. See [PRD.md](sprints/sprint1.md) for files, AC, and dependencies.
 
 - [ ] Phase 2: Multi-agent (orchestrator + coder + reviewer)
 - [ ] Phase 3: Self-reflection

--- a/docs/UserStory.md
+++ b/docs/UserStory.md
@@ -1,6 +1,6 @@
 # User Stories
 
-> Who uses the system and what workflows they follow. For acceptance criteria details, see [PRD.md](PRD.md). For system design, see [living-github-account.md](living-github-account.md).
+> Who uses the system and what workflows they follow. For acceptance criteria details, see [PRD.md](sprints/sprint1.md). For system design, see [living-github-account.md](living-github-account.md).
 
 ## Personas
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 > Formalized decisions from the system design. For full context on each decision, see [living-github-account.md](living-github-account.md).
 >
-> Related: [PRD](PRD.md) | [User Stories](UserStory.md)
+> Related: [PRD](sprints/sprint1.md) | [User Stories](UserStory.md)
 
 ## ADR-001: GitHub Actions as Agent Runtime
 

--- a/docs/living-github-account.md
+++ b/docs/living-github-account.md
@@ -3,7 +3,7 @@
 > System design for a self-evolving, agent-operated GitHub account.
 > Every component passes three gates: Is it the simplest approach? Does it duplicate anything? Do we need it now?
 >
-> Related: [ADRs](architecture.md) | [User Stories](UserStory.md) | [PRD](PRD.md)
+> Related: [ADRs](architecture.md) | [User Stories](UserStory.md) | [PRD](sprints/sprint1.md)
 
 ## Core Idea
 
@@ -163,7 +163,7 @@ Heartbeat runs:
 | ai-agents-research dispatches | `repository_dispatch` events | Phase 4+ |
 | Performance trends | `state/performance-log.jsonl` | Phase 3+ |
 
-**Goal types and cost gates**: Defined once in [PRD.md](PRD.md) Phase 1.
+**Goal types and cost gates**: Defined once in [PRD](sprints/sprint1.md) Phase 1.
 
 **Why the heartbeat, not the reflector**: The reflector runs daily. Idle discovery should happen within 15 minutes of the queue emptying. The heartbeat already runs at that cadence. DRY — don't add a second cron for the same trigger ("nothing to do").
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> Big-picture vision and phase progression. For detailed acceptance criteria, see [PRD.md](PRD.md). For system design, see [living-github-account.md](living-github-account.md).
+> Big-picture vision and phase progression. For detailed acceptance criteria, see [PRD](sprints/sprint1.md). For system design, see [living-github-account.md](living-github-account.md).
 
 ## Vision
 
@@ -8,7 +8,7 @@ The system bootstraps from 4 seed files to full autonomy across multiple reposit
 
 ## Phase Progression
 
-8 phases from bootstrap to full autonomy. See [PRD.md](PRD.md) for detailed acceptance criteria, added files, and dependencies per phase.
+8 phases from bootstrap to full autonomy. See [PRD](sprints/sprint1.md) for detailed acceptance criteria, added files, and dependencies per phase.
 
 | Phase | Name | Current Status |
 |-------|------|----------------|
@@ -30,7 +30,7 @@ Key design decisions are formalized as ADRs in [architecture.md](architecture.md
 Design complete. Seed file stubs and deployment guide ready. Remaining work is execution.
 
 - [x] System design ([living-github-account.md](living-github-account.md))
-- [x] PRD with phased AC ([PRD.md](PRD.md))
+- [x] PRD with phased AC ([PRD](sprints/sprint1.md))
 - [x] ADRs ([architecture.md](architecture.md))
 - [x] User stories ([UserStory.md](UserStory.md))
 - [x] Seed file stubs ([stubs/](stubs/))
@@ -42,7 +42,7 @@ Design complete. Seed file stubs and deployment guide ready. Remaining work is e
 
 ### Phase 1: Single-Agent Loop
 
-For added/modified files and AC, see [PRD Phase 1](PRD.md).
+For added/modified files and AC, see [PRD Phase 1](sprints/sprint1.md).
 
 - [ ] Add `goal-intake.yaml`, `agent-worker.yaml`, `performance-log.jsonl`
 - [ ] Update heartbeat and orchestrator prompt with goal execution + discovery
@@ -50,4 +50,4 @@ For added/modified files and AC, see [PRD Phase 1](PRD.md).
 
 ### Phase 2+
 
-Each phase depends on proving the previous. See [PRD](PRD.md) for files, AC, and dependencies.
+Each phase depends on proving the previous. See [PRD](sprints/sprint1.md) for files, AC, and dependencies.

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,11 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/usage/config/
+
+# Accept common "soft failure" status codes from bot-protected sites
+accept = [200, 204, 301, 401, 403, 429]
+
+# Exclude URLs that commonly fail in CI
+exclude = [
+  "https://github.com/qte77/liminal-flux-gh-acc/security/advisories/new",
+  "https://github.com/qte77/qte77/blob/main/AGENTS.md.*",
+]


### PR DESCRIPTION
Rewrites README to the estate doc-structure canon (#27) and fixes the Lint MD/Links failure (#18) by removing the docs/PRD.md symlink (it broke ../living-github-account.md when followed) and repointing all PRD references to docs/sprints/sprint1.md. Adds lychee.toml (accept codes + excludes two bot-protected URLs). Local lychee --offline: 0 errors.

Closes #27. Closes #18.

Generated with Claude <noreply@anthropic.com>